### PR TITLE
修改文档中数组操作的小问题

### DIFF
--- a/source/_posts/tutorial/data-method.md
+++ b/source/_posts/tutorial/data-method.md
@@ -191,7 +191,7 @@ san.defineComponent({
 ### pop
 
 ```
-{*} push({string|Object}expr, {Object?}option)
+{*} pop({string|Object}expr, {Object?}option)
 ```
 
 `解释`：
@@ -292,7 +292,7 @@ san.defineComponent({
 ### splice
 
 ```
-{Array} removeAt({string|Object}expr, {Array}spliceArgs, {Object?}option)
+{Array} splice({string|Object}expr, {Array}spliceArgs, {Object?}option)
 ```
 
 `解释`：


### PR DESCRIPTION
文档在描述数组的操作时有两处错误，对其进行了修改：
1、pop方法描述的代码函数写成了push
2、splice方法描述的代码函数写成了removeAt